### PR TITLE
Fix link to Links http://www.skryl.org/links?tag=links

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -43,7 +43,7 @@
 
 .row
   .col_6#links
-    h2= link_to 'Links', 'links?tag=link'
+    h2= link_to 'Links', 'links?tag=links'
     p Some inspiring #{link_to 'content', 'links?tag=link'} from around the web.
     ul
       - @links.each do |a|


### PR DESCRIPTION
It points to http://www.skryl.org/links?tag=link but the tag used in the data is "links" and not "link", so the correct
link is http://www.skryl.org/links?tag=links